### PR TITLE
Update angel3_hot.dart

### DIFF
--- a/packages/hot/lib/angel3_hot.dart
+++ b/packages/hot/lib/angel3_hot.dart
@@ -359,7 +359,7 @@ class HotReloader {
       scheduleMicrotask(() async {
         // Disconnect active WebSockets
         try {
-          var ws = _server!.app.container!.make<AngelWebSocket>()!;
+          var ws = _server!.app.container!.make<AngelWebSocket>();
 
           for (var client in ws.clients) {
             try {


### PR DESCRIPTION
Removed excess '!' operation which caused the following error message,
```
Warning: Operand of null-aware operation '!' has type 'AngelWebSocket' which excludes null.
../…/lib/angel3_hot.dart:362
- 'AngelWebSocket' is from 'package:angel3_websocket/server.dart' ('../../../../../.pub-cache/hosted/pub.dartlang.org/angel3_websocket-4.1.2/lib/server.dart').
package:angel3_websocket/server.dart:1
          var ws = _server!.app.container!.make<AngelWebSocket>()!;
```