### PR TITLE
fix: res.json() will cause 'Bad state: Cannot modify a closed respons…

### DIFF
--- a/packages/framework/lib/src/core/response_context.dart
+++ b/packages/framework/lib/src/core/response_context.dart
@@ -169,9 +169,8 @@ abstract class ResponseContext<RawResponse>
   }
 
   /// Serializes JSON to the response.
-  void json(value) => this
-    ..contentType = MediaType('application', 'json')
-    ..serialize(value);
+  Future<bool> json(value) =>
+      this.serialize(value, contentType: MediaType('application', 'json'));
 
   /// Returns a JSONP response.
   ///


### PR DESCRIPTION
When I writen a simple api like this:
```dart
Future configureServer(Angel app) async {
  app.get('/test', (req, res) => res.json({"test": "ok"}));
}
```
I got this error:
```shell
[SEVERE] service_proxy: Bad state: Cannot modify a closed response.

Bad state: Cannot modify a closed response.
package:angel3_framework/src/core/response_context.dart 309:7  ResponseContext.serialize
package:angel3_framework/src/core/server.dart 280:20           Angel.executeHandler.<fn>
dart:async                                                     _CustomZone.runUnary
package:angel3_framework/src/core/driver.dart 414:22           Driver.runPipeline
package:angel3_hot/angel3_hot.dart 119:14                      HotReloader.handleRequest
```

I think it was caused by the `json()` should not return the type of `ResponseContext`.
In addition, in `serialize(value, {MediaType? contentType})`, `this.contentType` will set to optional param `contentType`, so I think the code of `..contentType = MediaType('application', 'json')` in  `json()` is unavailing.