### PR TITLE
Update angel3_jinja.dart

### DIFF
--- a/packages/jinja/lib/angel3_jinja.dart
+++ b/packages/jinja/lib/angel3_jinja.dart
@@ -47,7 +47,7 @@ AngelConfigurer jinja({
     );
 
     app.viewGenerator = (path, [values]) {
-      return env.getTemplate(path).render(values) as String;
+      return env.getTemplate(path).render.renderMap(values) as String;
     };
   };
 }


### PR DESCRIPTION
This fix will make `angel3_jinja` works well again with `jinja: ^0.3.4`.

Before :
![截图录屏_选择区域_20211202145648](https://user-images.githubusercontent.com/19624835/144373178-dfc03be3-af44-401d-b4d7-d36c5ea2c832.png)

After:
![截图录屏_选择区域_20211202145714](https://user-images.githubusercontent.com/19624835/144373220-25b63205-804d-4cbc-bdcb-f71085785340.png)

