### PR TITLE
fix wrong sql generated when using multi 'orderBy'

### DIFF
--- a/packages/orm/angel_orm/lib/src/query.dart
+++ b/packages/orm/angel_orm/lib/src/query.dart
@@ -331,7 +331,7 @@ abstract class Query<T, Where extends QueryWhere> extends QueryBase<T> {
       b.write(' WHERE $whereClause');
     }
     if (_groupBy != null) b.write(' GROUP BY $_groupBy');
-    var orderByClause = _orderBy.map(item.compile()).join(', ');
+    var orderByClause = _orderBy.map((order) => order.compile()).join(', ');
     if  (orderByClause?.isNotEmpty == true) {
       b.write(' ORDER BY $orderByClause');
     }

--- a/packages/orm/angel_orm/lib/src/query.dart
+++ b/packages/orm/angel_orm/lib/src/query.dart
@@ -332,7 +332,7 @@ abstract class Query<T, Where extends QueryWhere> extends QueryBase<T> {
     }
     if (_groupBy != null) b.write(' GROUP BY $_groupBy');
     var orderByClause = _orderBy.map((order) => order.compile()).join(', ');
-    if  (orderByClause?.isNotEmpty == true) {
+    if (orderByClause.isNotEmpty == true) {
       b.write(' ORDER BY $orderByClause');
     }
     if (_limit != null) b.write(' LIMIT $_limit');

--- a/packages/orm/angel_orm/lib/src/query.dart
+++ b/packages/orm/angel_orm/lib/src/query.dart
@@ -331,8 +331,9 @@ abstract class Query<T, Where extends QueryWhere> extends QueryBase<T> {
       b.write(' WHERE $whereClause');
     }
     if (_groupBy != null) b.write(' GROUP BY $_groupBy');
-    for (var item in _orderBy) {
-      b.write(' ORDER BY ${item.compile()}');
+    var orderByClause = _orderBy.map(item.compile()).join(', ');
+    if  (orderByClause?.isNotEmpty == true) {
+      b.write(' ORDER BY $orderByClause');
     }
     if (_limit != null) b.write(' LIMIT $_limit');
     if (_offset != null) b.write(' OFFSET $_offset');

--- a/packages/orm/angel_orm_test/lib/src/join_test.dart
+++ b/packages/orm/angel_orm_test/lib/src/join_test.dart
@@ -80,4 +80,12 @@ void joinTests(FutureOr<QueryExecutor> Function() createExecutor,
             element.personAge == originalPerson?.age),
         true);
   });
+
+  test('select orders with multi order by fields', () async {
+    var query = PersonOrderQuery();
+    query.orderBy(PersonOrderFields.personId, descending: true);
+    query.orderBy(PersonOrderFields.id, descending: true);
+    var orders = await query.get(executor);
+    expect(orders.first.personId > orders.last.personId, true);
+  });
 }

--- a/packages/orm/angel_orm_test/lib/src/join_test.dart
+++ b/packages/orm/angel_orm_test/lib/src/join_test.dart
@@ -82,9 +82,9 @@ void joinTests(FutureOr<QueryExecutor> Function() createExecutor,
 
   test('select orders with multi order by fields', () async {
     var query = PersonOrderQuery();
-    query.orderBy(PersonOrderFields.personId, descending: true);
     query.orderBy(PersonOrderFields.id, descending: true);
+    query.orderBy(PersonOrderFields.personId, descending: true);
     var orders = await query.get(executor);
-    expect(orders.first.personId! > orders.last.personId!, true);
+    expect(orders.first.idAsInt > orders.last.idAsInt, true);
   });
 }

--- a/packages/orm/angel_orm_test/lib/src/join_test.dart
+++ b/packages/orm/angel_orm_test/lib/src/join_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:angel3_orm/angel3_orm.dart';
 import 'package:test/test.dart';
@@ -86,6 +85,6 @@ void joinTests(FutureOr<QueryExecutor> Function() createExecutor,
     query.orderBy(PersonOrderFields.personId, descending: true);
     query.orderBy(PersonOrderFields.id, descending: true);
     var orders = await query.get(executor);
-    expect(orders.first.personId > orders.last.personId, true);
+    expect(orders.first.personId! > orders.last.personId!, true);
   });
 }


### PR DESCRIPTION
When call `orderBy` multi times, the generated will be like: 
```sql
select id, name from users order by id desc order by updated_at desc;
```
but correct shoule be:
```sql
select id, name from users order by id desc, updated_at desc;
```

Test code added and all test passed ~