### PR TITLE
MariaDbMigrationRunner assumed "batch" column to be string, but was int

### DIFF
--- a/packages/orm/angel_migration_runner/lib/src/mariadb/runner.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mariadb/runner.dart
@@ -71,7 +71,11 @@ class MariaDbMigrationRunner implements MigrationRunner {
       var curBatch = 0;
       if (result.isNotEmpty) {
         var firstRow = result.toList();
-        curBatch = int.tryParse(firstRow[0][0] ?? '0') as int;
+        var firstBatch = firstRow[0][0] ?? 0;
+        if (firstBatch is! int) {
+          int.tryParse(firstBatch) as int;
+        }
+        curBatch = firstBatch;
       }
       var batch = curBatch + 1;
 
@@ -105,7 +109,11 @@ class MariaDbMigrationRunner implements MigrationRunner {
     var curBatch = 0;
     if (result.isNotEmpty) {
       var firstRow = result.toList();
-      curBatch = int.tryParse(firstRow[0][0]) as int;
+      var firstBatch = firstRow[0][0];
+      if (firstBatch is! int) {
+        int.tryParse(firstBatch) as int;
+      }
+      curBatch = firstBatch;
     }
 
     result = await connection


### PR DESCRIPTION
When running the `MariaDbMigrationRunner´ in my tests, it turned out that the `batch` column of the `migrations` table created previously was an `int(11)` instead of a `varchar` column. This PR introduces a type check while reading out the actual `batch` value.

Some warnings:
 * I could not find any existing tests to expand, and my knowledge of the framework is too limited to try to come up with my own. 
 * I had a quick glance at other usages of the `batch` column, and it seems the `MySql` and `Postgres` `MigrationRunner`s might potentially have the same issue?
 * Also, it seems that this issue might have been present for a long time, as the `CREATE TABLE IF NOT EXISTS migrations` statements all are using `batch integer` since at least a year ago.